### PR TITLE
change to the collision layer and player detection

### DIFF
--- a/Scenes/BaseWorld/BaseWorld.gd
+++ b/Scenes/BaseWorld/BaseWorld.gd
@@ -19,6 +19,3 @@ func set_pc_shooting(shooting_flag : bool = true):
 
 func _on_player_character_projectile_shot(projectile_velocity):
 	pc_shoots_projectile(projectile_velocity)
-
-func _ready():
-	get_tree().set_group("enemies", "player_node", pc_node)

--- a/Scenes/EnemyCharacter/EnemyCharacter.gd
+++ b/Scenes/EnemyCharacter/EnemyCharacter.gd
@@ -4,8 +4,11 @@ extends CharacterBody2D
 
 var player_node : CharacterBody2D
 
+
 func _physics_process(delta):
-	if not player_node: return
+	if not player_node:
+		player_node = get_tree().get_first_node_in_group("player")
+		return
 	
 	velocity = position.direction_to(player_node.position) * movement_speed
 	move_and_slide()

--- a/Scenes/EnemyCharacter/EnemyCharacter.tscn
+++ b/Scenes/EnemyCharacter/EnemyCharacter.tscn
@@ -1,12 +1,12 @@
 [gd_scene load_steps=4 format=3 uid="uid://cjpv7pmyt7546"]
 
 [ext_resource type="Script" path="res://Scenes/EnemyCharacter/EnemyCharacter.gd" id="1_ckq15"]
-[ext_resource type="Texture2D" uid="uid://b45vjjguxj2i" path="res://Assets/Originals/Sprite/characters_concept.png" id="1_j6xe7"]
+[ext_resource type="Texture2D" uid="uid://23tvsjfw562d" path="res://Assets/Originals/Sprite/characters_concept.png" id="1_j6xe7"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_3s8qn"]
 
 [node name="EnemyCharacter" type="CharacterBody2D" groups=["enemies"]]
-collision_mask = 3
+collision_mask = 7
 script = ExtResource("1_ckq15")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]

--- a/Scenes/Pickups/Pickup.gd
+++ b/Scenes/Pickups/Pickup.gd
@@ -1,29 +1,24 @@
 extends CharacterBody2D
 
 var moving_speed = 10
-
 var player_node : CharacterBody2D
-var following = false
 
 
 func _physics_process(delta):
-	if not (following and player_node): return
+	if not player_node: return
 	
 	velocity = position.direction_to(player_node.position) * moving_speed
 	move_and_slide()
 
 
 func _on_player_detection_area_body_entered(body):
-	if body == player_node:
-		following = true
+	player_node = body
 
 
 func _on_player_detection_area_body_exited(body):
-	if body == player_node:
-		following = false
+	player_node = null
 
 
 func _on_picked_up_area_body_entered(body):
-	if body == player_node:
-		print("picked up")
-		# the item get picked up by the player, queue_free(), sfx, etc should go there
+	print("picked up")
+	# the item get picked up by the player, queue_free(), sfx, etc should go there

--- a/Scenes/Pickups/Pickup.tscn
+++ b/Scenes/Pickups/Pickup.tscn
@@ -24,12 +24,16 @@ texture = ExtResource("2_mqje3")
 
 [node name="PickedUpArea" type="Area2D" parent="."]
 editor_description = "This area define the range where the player should be to pick up the item"
+collision_layer = 0
+collision_mask = 4
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="PickedUpArea"]
 shape = SubResource("CircleShape2D_be53y")
 
 [node name="PlayerDetectionArea" type="Area2D" parent="."]
 editor_description = "This area define the range at which the pickup item will start to follow the player"
+collision_layer = 0
+collision_mask = 4
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="PlayerDetectionArea"]
 shape = SubResource("CircleShape2D_xddg5")

--- a/Scenes/PlayerCharacter/PlayerCharacter.tscn
+++ b/Scenes/PlayerCharacter/PlayerCharacter.tscn
@@ -1,11 +1,11 @@
 [gd_scene load_steps=30 format=3 uid="uid://cbso5w5o34udn"]
 
 [ext_resource type="Script" path="res://Scenes/PlayerCharacter/PlayerCharacter.gd" id="1_8numc"]
-[ext_resource type="Texture2D" uid="uid://b0vfiq1w0qkts" path="res://Assets/Originals/Sprite/alex_legs_sheet.png" id="2_wyi4t"]
+[ext_resource type="Texture2D" uid="uid://bpjewkd2jhrgf" path="res://Assets/Originals/Sprite/alex_legs_sheet.png" id="2_wyi4t"]
 [ext_resource type="PackedScene" uid="uid://blat6y3xgu67s" path="res://Scenes/StackedSprite/StackedSprite2D.tscn" id="3_lj23u"]
-[ext_resource type="Texture2D" uid="uid://cquohajeu50sq" path="res://Assets/Originals/Sprite/alex_head_sheet.png" id="4_af3j5"]
-[ext_resource type="Texture2D" uid="uid://bcfxlhyp5fj1r" path="res://Assets/Originals/Sprite/Alex_body_9.png" id="4_b3k0q"]
-[ext_resource type="Texture2D" uid="uid://bxed5qbba67hm" path="res://Assets/Originals/Sprite/alex_eyes_sheet.png" id="6_lxc57"]
+[ext_resource type="Texture2D" uid="uid://c68fhb0j1bftc" path="res://Assets/Originals/Sprite/alex_head_sheet.png" id="4_af3j5"]
+[ext_resource type="Texture2D" uid="uid://dx0ktb4vdrbiv" path="res://Assets/Originals/Sprite/Alex_body_9.png" id="4_b3k0q"]
+[ext_resource type="Texture2D" uid="uid://hhnnkf70838h" path="res://Assets/Originals/Sprite/alex_eyes_sheet.png" id="6_lxc57"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_ox0bi"]
 radius = 5.0
@@ -435,7 +435,9 @@ transitions = ["Start", "Idle", SubResource("AnimationNodeStateMachineTransition
 
 [sub_resource type="AnimationNodeStateMachinePlayback" id="AnimationNodeStateMachinePlayback_k1fvu"]
 
-[node name="PlayerCharacter" type="CharacterBody2D"]
+[node name="PlayerCharacter" type="CharacterBody2D" groups=["player"]]
+collision_layer = 4
+collision_mask = 3
 script = ExtResource("1_8numc")
 cooldown = 0.6
 

--- a/project.godot
+++ b/project.godot
@@ -93,6 +93,7 @@ interact={
 
 2d_physics/layer_1="entities"
 2d_physics/layer_2="walls"
+2d_physics/layer_3="player"
 
 [rendering]
 


### PR DESCRIPTION
-renamed layer 3 of physics 2D to player
-player body get this layer and also the group player -enemies don't need the BaseWorld to update the player node for them as they can now get it by player_node = get_tree().get_first_node_in_group("player") area like pickups item can detect if crossed by the player simply by scanning only layer 3